### PR TITLE
Region addition and basic editing

### DIFF
--- a/assets/prefabs/hubtool.prefab
+++ b/assets/prefabs/hubtool.prefab
@@ -10,5 +10,6 @@
     "InteractionScreen": {
         "screen": "Scenario:HubToolScreen"
     },
-    "Expanded": {}
+    "Expanded": {},
+    "Visibility": {}
 }

--- a/assets/prefabs/playerRegionConditional.prefab
+++ b/assets/prefabs/playerRegionConditional.prefab
@@ -1,0 +1,11 @@
+{
+    "Conditional":{},
+    "ShortName":{
+        "name":"Player in region"
+    },
+    "PlayerRegion":{},
+    "Text":{
+        "text":"Is [player:Player] inside of [region:Region]"
+    },
+    "ArgumentContainer":{}
+}

--- a/assets/prefabs/scenarioConstantRegion.prefab
+++ b/assets/prefabs/scenarioConstantRegion.prefab
@@ -1,0 +1,7 @@
+{
+    "ScenarioRegion":{},
+    "ShortName":{
+        "name":"Constant Region"
+    },
+    "ConstRegion":{}
+}

--- a/assets/ui/editRegionScreen.ui
+++ b/assets/ui/editRegionScreen.ui
@@ -109,6 +109,26 @@
               ]
             },
             {
+              "type": "RowLayout",
+              "id": "teleportLayout",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "colorLayout",
+                  "target": "BOTTOM",
+                  "offset": 40
+                },
+                "use-content-height": true
+              },
+              "contents": [
+                {
+                  "type": "engine:UIButton",
+                  "id": "teleportButton",
+                  "layoutInfo": {},
+                  "text": "Teleport to region"
+                }
+              ]
+            },
+            {
               "type": "engine:RowLayout",
               "id": "buttonLayout",
               "layoutInfo": {

--- a/assets/ui/editRegionScreen.ui
+++ b/assets/ui/editRegionScreen.ui
@@ -1,0 +1,139 @@
+{
+  "type": "EditRegionScreen",
+  "contents": {
+    "type": "RelativeLayout",
+    "contents": [
+      {
+        "type": "engine:UIBox",
+        "id": "newWidget",
+        "layoutInfo": {
+          "width": 400,
+          "height": 300,
+          "position-vertical-center": {},
+          "position-horizontal-center": {}
+        },
+        "content": {
+          "type": "RelativeLayout",
+          "contents": [
+            {
+              "type": "engine:UILabel",
+              "id": "editLabel",
+              "layoutInfo": {
+                "position-top": {},
+                "position-horizontal-center": {},
+                "use-content-height": true
+              },
+              "text": "Edit Region"
+            },
+            {
+              "type": "RowLayout",
+              "id": "selectionLayout",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "editLabel",
+                  "target": "BOTTOM",
+                  "offset": 5
+                },
+                "use-content-height": true
+              },
+              "contents": [
+                {
+                  "type": "engine:UILabel",
+                  "id": "selectLabel",
+                  "layoutInfo": {},
+                  "text": "Region Name"
+                },
+                {
+                  "type": "engine:UIText",
+                  "id": "nameEntry",
+                  "layoutInfo": {}
+                }
+              ]
+            },
+            {
+              "type": "RowLayout",
+              "id": "visibilityLayout",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "selectionLayout",
+                  "target": "BOTTOM",
+                  "offset": 5
+                },
+                "use-content-height": true
+              },
+              "contents": [
+                {
+                  "type": "engine:UILabel",
+                  "id": "visibilityLabel",
+                  "layoutInfo": {},
+                  "text": "Visibility"
+                },
+                {
+                  "type": "engine:UICheckbox",
+                  "id": "visibility",
+                  "layoutInfo": {}
+                }
+              ]
+            },
+            {
+              "type": "RowLayout",
+              "id": "colorLayout",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "visibilityLayout",
+                  "target": "BOTTOM",
+                  "offset": 5
+                },
+                "use-content-height": true
+              },
+              "contents": [
+                {
+                  "type": "engine:UILabel",
+                  "id": "colorLabel",
+                  "layoutInfo": {},
+                  "text": "Color"
+                },
+                {
+                  "type": "engine:UISlider",
+                  "id": "colorSlider",
+                  "layoutInfo": {}
+                },
+                {
+                  "type": "engine:UIImage",
+                  "id": "colorImage",
+                  "layoutInfo": {
+                    "relativeWidth": 0.1
+                  },
+                  "skin": "framed_image"
+                }
+              ]
+            },
+            {
+              "type": "engine:RowLayout",
+              "id": "buttonLayout",
+              "layoutInfo": {
+                "height": 50,
+                "position-bottom": {}
+              },
+              "contents": [
+                {
+                  "type": "engine:UIButton",
+                  "id": "okButton",
+                  "layoutInfo": {},
+                  "text": "Accept"
+                },
+                {
+                  "type": "engine:UIButton",
+                  "id": "cancelButton",
+                  "layoutInfo": {},
+                  "text": "Cancel"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "skin": "engine:default"
+}

--- a/assets/ui/hubToolScreen.ui
+++ b/assets/ui/hubToolScreen.ui
@@ -133,10 +133,10 @@
                   "content": {
                     "type": "RelativeLayout",
                     "layoutInfo": {
-                        "position-top": {
-                            "widget": "ButtonLayout",
-                            "target": "BOTTOM"
-                        }
+                      "position-top": {
+                        "widget": "ButtonLayout",
+                        "target": "BOTTOM"
+                      }
                     },
                     "contents": [
                       {
@@ -148,7 +148,7 @@
                           "layoutInfo": {}
                         },
                         "layoutInfo": {
-                            "position-top":{}
+                          "position-top": {}
                         }
                       }
                     ]
@@ -161,8 +161,28 @@
                   "visible": false,
                   "content": {
                     "type": "RelativeLayout",
-                    "layoutInfo": {},
-                    "contents": []
+                    "layoutInfo": {
+                      "position-top": {
+                        "widget": "ButtonLayout",
+                        "target": "BOTTOM"
+                      }
+                    },
+                    "contents": [
+                      {
+                        "type": "engine:ScrollableArea",
+                        "id": "scrollAreaRegions",
+                        "layoutInfo": {
+                          "position-top": {}
+                        },
+                        "contents": [
+                          {
+                            "type": "Scenario:RegionTreeView",
+                            "id": "RegionTree",
+                            "layoutInfo": {}
+                          }
+                        ]
+                      }
+                    ]
                   }
                 }
               ]

--- a/src/main/java/org/terasology/scenario/components/VisibilityComponent.java
+++ b/src/main/java/org/terasology/scenario/components/VisibilityComponent.java
@@ -18,14 +18,9 @@ package org.terasology.scenario.components;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
-/**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
- */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
-
-    public List<EntityRef> regionEntities = new ArrayList<>();
+public class VisibilityComponent implements Component {
+    public Set<EntityRef> visibleList = new HashSet<>();
 }

--- a/src/main/java/org/terasology/scenario/components/actions/ArgumentContainerComponent.java
+++ b/src/main/java/org/terasology/scenario/components/actions/ArgumentContainerComponent.java
@@ -20,6 +20,9 @@ import org.terasology.entitySystem.entity.EntityRef;
 
 import java.util.Map;
 
+/**
+ * Component that contains the arguments for the variables indicated in the text of the entity
+ */
 public class ArgumentContainerComponent implements Component {
     public Map<String, EntityRef> arguments;
 }

--- a/src/main/java/org/terasology/scenario/components/conditionals/PlayerRegionComponent.java
+++ b/src/main/java/org/terasology/scenario/components/conditionals/PlayerRegionComponent.java
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.components.conditionals;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
-
-import java.util.HashSet;
-import java.util.Set;
 
 /**
- * Component attached to a hubtool that includes a set of all of the region entities that should be visible to the
- * local player (visibility of the regions are ticked to true)
+ * Component to denote that a conditional is of type player in region conditional
  */
-public class VisibilityComponent implements Component {
-    public Set<EntityRef> visibleList = new HashSet<>();
+public class PlayerRegionComponent implements Component {
 }

--- a/src/main/java/org/terasology/scenario/components/information/ConstComparatorComponent.java
+++ b/src/main/java/org/terasology/scenario/components/information/ConstComparatorComponent.java
@@ -19,11 +19,43 @@ import org.terasology.entitySystem.Component;
 
 public class ConstComparatorComponent implements Component {
     public enum comparison {
-        GREATER_THAN,
-        LESS_THAN,
-        EQUAL_TO,
-        GREATER_THAN_EQUAL_TO,
-        LESS_THAN_EQUAL_TO
+        GREATER_THAN(">") {
+            public boolean evaluate(int x, int y) {
+                return x > y;
+            }
+        },
+        LESS_THAN("<") {
+            public boolean evaluate(int x, int y) {
+                return x < y;
+            }
+        },
+        EQUAL_TO("=") {
+            public boolean evaluate(int x, int y) {
+                return x == y;
+            }
+        },
+        GREATER_THAN_EQUAL_TO(">=") {
+            public boolean evaluate(int x, int y) {
+                return x >= y;
+            }
+        },
+        LESS_THAN_EQUAL_TO("<=") {
+            public boolean evaluate(int x, int y) {
+                return x <= y;
+            }
+        };
+
+        private String stringRepresentation;
+
+        comparison(String stringRepresentation) {
+            this.stringRepresentation = stringRepresentation;
+        }
+
+        public String toString() {
+            return stringRepresentation;
+        }
+
+        public abstract boolean evaluate(int x, int y);
     }
 
     public comparison compare = comparison.EQUAL_TO;

--- a/src/main/java/org/terasology/scenario/components/information/ConstRegionComponent.java
+++ b/src/main/java/org/terasology/scenario/components/information/ConstRegionComponent.java
@@ -13,18 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.components.information;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 
-import java.util.HashSet;
-import java.util.Set;
-
-/**
- * Component attached to a hubtool that includes a set of all of the region entities that should be visible to the
- * local player (visibility of the regions are ticked to true)
- */
-public class VisibilityComponent implements Component {
-    public Set<EntityRef> visibleList = new HashSet<>();
+public class ConstRegionComponent implements Component {
+    public EntityRef regionEntity;
 }

--- a/src/main/java/org/terasology/scenario/components/information/IndentificationComponents/ScenarioRegionComponent.java
+++ b/src/main/java/org/terasology/scenario/components/information/IndentificationComponents/ScenarioRegionComponent.java
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.components.information.IndentificationComponents;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
 
-import java.util.HashSet;
-import java.util.Set;
-
-/**
- * Component attached to a hubtool that includes a set of all of the region entities that should be visible to the
- * local player (visibility of the regions are ticked to true)
- */
-public class VisibilityComponent implements Component {
-    public Set<EntityRef> visibleList = new HashSet<>();
+public class ScenarioRegionComponent implements Component {
 }

--- a/src/main/java/org/terasology/scenario/components/regions/RegionBeingCreatedComponent.java
+++ b/src/main/java/org/terasology/scenario/components/regions/RegionBeingCreatedComponent.java
@@ -13,19 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.components.regions;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.terasology.math.geom.Vector3i;
 
 /**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
+ * Component indicating that this region is the one currently being created and should listen to edits
  */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
-
-    public List<EntityRef> regionEntities = new ArrayList<>();
+public class RegionBeingCreatedComponent implements Component {
+    public Vector3i firstHit;
 }

--- a/src/main/java/org/terasology/scenario/components/regions/RegionColorComponent.java
+++ b/src/main/java/org/terasology/scenario/components/regions/RegionColorComponent.java
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.components.regions;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.rendering.nui.Color;
 
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
- */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
-
-    public List<EntityRef> regionEntities = new ArrayList<>();
+public class RegionColorComponent implements Component {
+    public Color color = Color.WHITE;
 }

--- a/src/main/java/org/terasology/scenario/components/regions/RegionLocationComponent.java
+++ b/src/main/java/org/terasology/scenario/components/regions/RegionLocationComponent.java
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.components.regions;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.Region3i;
 
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
- */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
-
-    public List<EntityRef> regionEntities = new ArrayList<>();
+public class RegionLocationComponent implements Component {
+    public Region3i region;
 }

--- a/src/main/java/org/terasology/scenario/components/regions/RegionNameComponent.java
+++ b/src/main/java/org/terasology/scenario/components/regions/RegionNameComponent.java
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.components.regions;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
 
-import java.util.ArrayList;
-import java.util.List;
-
-/**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
- */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
-
-    public List<EntityRef> regionEntities = new ArrayList<>();
+public class RegionNameComponent implements Component {
+    public String regionName = "New Region";
 }

--- a/src/main/java/org/terasology/scenario/internal/events/RegionRecolorEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionRecolorEvent.java
@@ -17,38 +17,26 @@ package org.terasology.scenario.internal.events;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.rendering.nui.Color;
 import org.terasology.scenario.internal.ui.HubToolScreen;
-import org.terasology.scenario.internal.ui.LogicTree.LogicTreeValue;
 
-public class LogicTreeMoveEntityEvent implements Event {
-    private EntityRef triggerEntity;
-    private EntityRef moveEntity;
-    private LogicTreeValue.Type elementType;
-    private int index;
+public class RegionRecolorEvent implements Event {
+    private EntityRef entity;
+    private Color newColor;
     private HubToolScreen hubToolScreen;
 
-    public LogicTreeMoveEntityEvent(EntityRef triggerEntity, EntityRef moveEntity, LogicTreeValue.Type elementType, int index, HubToolScreen hubToolScreen) {
-        this.triggerEntity = triggerEntity;
-        this.moveEntity = moveEntity;
-        this.elementType = elementType;
-        this.index = index;
+    public RegionRecolorEvent(EntityRef entity, Color newColor, HubToolScreen hubToolScreen) {
+        this.entity = entity;
+        this.newColor = newColor;
         this.hubToolScreen = hubToolScreen;
     }
 
-    public EntityRef getTriggerEntity() {
-        return triggerEntity;
+    public EntityRef getRegionEntity() {
+        return entity;
     }
 
-    public EntityRef getMoveEntity() {
-        return moveEntity;
-    }
-
-    public LogicTreeValue.Type getElementType() {
-        return elementType;
-    }
-
-    public int getIndex() {
-        return index;
+    public Color getNewColor() {
+        return newColor;
     }
 
     public HubToolScreen getHubScreen() {

--- a/src/main/java/org/terasology/scenario/internal/events/RegionRenameEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionRenameEvent.java
@@ -18,37 +18,24 @@ package org.terasology.scenario.internal.events;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.scenario.internal.ui.HubToolScreen;
-import org.terasology.scenario.internal.ui.LogicTree.LogicTreeValue;
 
-public class LogicTreeMoveEntityEvent implements Event {
-    private EntityRef triggerEntity;
-    private EntityRef moveEntity;
-    private LogicTreeValue.Type elementType;
-    private int index;
+public class RegionRenameEvent implements Event {
+    private EntityRef entity;
+    private String newName;
     private HubToolScreen hubToolScreen;
 
-    public LogicTreeMoveEntityEvent(EntityRef triggerEntity, EntityRef moveEntity, LogicTreeValue.Type elementType, int index, HubToolScreen hubToolScreen) {
-        this.triggerEntity = triggerEntity;
-        this.moveEntity = moveEntity;
-        this.elementType = elementType;
-        this.index = index;
+    public RegionRenameEvent(EntityRef entity, String newName, HubToolScreen hubToolScreen) {
+        this.entity = entity;
+        this.newName = newName;
         this.hubToolScreen = hubToolScreen;
     }
 
-    public EntityRef getTriggerEntity() {
-        return triggerEntity;
+    public EntityRef getRegionEntity() {
+        return entity;
     }
 
-    public EntityRef getMoveEntity() {
-        return moveEntity;
-    }
-
-    public LogicTreeValue.Type getElementType() {
-        return elementType;
-    }
-
-    public int getIndex() {
-        return index;
+    public String getNewName() {
+        return newName;
     }
 
     public HubToolScreen getHubScreen() {

--- a/src/main/java/org/terasology/scenario/internal/events/RegionTreeAddEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionTreeAddEvent.java
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.internal.events;
 
-import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.scenario.internal.ui.HubToolScreen;
 
-import java.util.ArrayList;
-import java.util.List;
+public class RegionTreeAddEvent implements Event {
+    private HubToolScreen hubScreen;
 
-/**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
- */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
+    public RegionTreeAddEvent(HubToolScreen hubScreen) {
+        this.hubScreen = hubScreen;
+    }
 
-    public List<EntityRef> regionEntities = new ArrayList<>();
+    public HubToolScreen getHubScreen() {
+        return hubScreen;
+    }
 }

--- a/src/main/java/org/terasology/scenario/internal/events/RegionTreeDeleteEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionTreeDeleteEvent.java
@@ -13,19 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.internal.events;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.scenario.internal.ui.HubToolScreen;
 
-import java.util.ArrayList;
-import java.util.List;
+public class RegionTreeDeleteEvent implements Event {
+    private HubToolScreen hubScreen;
+    private EntityRef deleteEntity;
 
-/**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
- */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
+    public RegionTreeDeleteEvent(HubToolScreen hubScreen, EntityRef deleteEntity) {
+        this.hubScreen = hubScreen;
+        this.deleteEntity = deleteEntity;
+    }
 
-    public List<EntityRef> regionEntities = new ArrayList<>();
+    public HubToolScreen getHubScreen() {
+        return hubScreen;
+    }
+
+    public EntityRef getDeleteEntity() {
+        return deleteEntity;
+    }
 }

--- a/src/main/java/org/terasology/scenario/internal/events/RegionTreeFullAddEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionTreeFullAddEvent.java
@@ -13,19 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.internal.events;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
 
-import java.util.ArrayList;
-import java.util.List;
+public class RegionTreeFullAddEvent implements Event {
+    private EntityRef addEntity;
+    private EntityRef adder;
 
-/**
- * Component attached to a scenario entity. Denotes the "root" of the logic structure.
- */
-public class ScenarioComponent implements Component {
-    public List<EntityRef> triggerEntities  = new ArrayList<>();
+    public RegionTreeFullAddEvent(EntityRef addEntity, EntityRef adder) {
+        this.addEntity = addEntity;
+        this.adder = adder;
+    }
 
-    public List<EntityRef> regionEntities = new ArrayList<>();
+    public EntityRef getAddEntity() {
+        return addEntity;
+    }
+
+    public EntityRef getAdder() {
+        return adder;
+    }
 }

--- a/src/main/java/org/terasology/scenario/internal/events/RegionTreeMoveEntityEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionTreeMoveEntityEvent.java
@@ -18,33 +18,20 @@ package org.terasology.scenario.internal.events;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
 import org.terasology.scenario.internal.ui.HubToolScreen;
-import org.terasology.scenario.internal.ui.LogicTree.LogicTreeValue;
 
-public class LogicTreeMoveEntityEvent implements Event {
-    private EntityRef triggerEntity;
+public class RegionTreeMoveEntityEvent implements Event {
     private EntityRef moveEntity;
-    private LogicTreeValue.Type elementType;
     private int index;
     private HubToolScreen hubToolScreen;
 
-    public LogicTreeMoveEntityEvent(EntityRef triggerEntity, EntityRef moveEntity, LogicTreeValue.Type elementType, int index, HubToolScreen hubToolScreen) {
-        this.triggerEntity = triggerEntity;
+    public RegionTreeMoveEntityEvent(EntityRef moveEntity, int index, HubToolScreen hubToolScreen) {
         this.moveEntity = moveEntity;
-        this.elementType = elementType;
         this.index = index;
         this.hubToolScreen = hubToolScreen;
     }
 
-    public EntityRef getTriggerEntity() {
-        return triggerEntity;
-    }
-
     public EntityRef getMoveEntity() {
         return moveEntity;
-    }
-
-    public LogicTreeValue.Type getElementType() {
-        return elementType;
     }
 
     public int getIndex() {

--- a/src/main/java/org/terasology/scenario/internal/events/evaluationEvents/EvaluateRegionEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/evaluationEvents/EvaluateRegionEvent.java
@@ -13,18 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.components;
+package org.terasology.scenario.internal.events.evaluationEvents;
 
-import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
 
-import java.util.HashSet;
-import java.util.Set;
+public class EvaluateRegionEvent implements Event {
+    private EntityRef result;
+    private EntityRef passedEntity;
 
-/**
- * Component attached to a hubtool that includes a set of all of the region entities that should be visible to the
- * local player (visibility of the regions are ticked to true)
- */
-public class VisibilityComponent implements Component {
-    public Set<EntityRef> visibleList = new HashSet<>();
+    public EvaluateRegionEvent(EntityRef passed) {
+        this.passedEntity = passed;
+    }
+
+    public void setResult(EntityRef result) {
+        this.result = result;
+    }
+
+    public EntityRef getResult() {
+        return result;
+    }
+
+    public void setPassedEntity(EntityRef entity) {
+        this.passedEntity = entity;
+    }
+
+    public EntityRef getPassedEntity() {
+        return passedEntity;
+    }
 }

--- a/src/main/java/org/terasology/scenario/internal/systems/ComponentEvaluation/EvaluationDisplaySystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/ComponentEvaluation/EvaluationDisplaySystem.java
@@ -84,23 +84,7 @@ public class EvaluationDisplaySystem extends BaseComponentSystem {
 
     @ReceiveEvent //Comparator
     public void onEvaluateStringEvent(EvaluateDisplayEvent event, EntityRef entity, ConstComparatorComponent comp) {
-        switch (comp.compare) {
-            case EQUAL_TO:
-                event.setResult("=");
-                break;
-            case GREATER_THAN:
-                event.setResult(">");
-                break;
-            case GREATER_THAN_EQUAL_TO:
-                event.setResult(">=");
-                break;
-            case LESS_THAN:
-                event.setResult("<");
-                break;
-            case LESS_THAN_EQUAL_TO:
-                event.setResult("<=");
-                break;
-        }
+        event.setResult(comp.compare.toString());
     }
 
     @ReceiveEvent

--- a/src/main/java/org/terasology/scenario/internal/systems/ComponentEvaluation/EvaluationDisplaySystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/ComponentEvaluation/EvaluationDisplaySystem.java
@@ -30,12 +30,14 @@ import org.terasology.scenario.components.information.ConstBlockComponent;
 import org.terasology.scenario.components.information.ConstComparatorComponent;
 import org.terasology.scenario.components.information.ConstIntegerComponent;
 import org.terasology.scenario.components.information.ConstItemPrefabComponent;
+import org.terasology.scenario.components.information.ConstRegionComponent;
 import org.terasology.scenario.components.information.ConstStringComponent;
 import org.terasology.scenario.components.information.ItemCountComponent;
 import org.terasology.scenario.components.information.PlayerComponent;
 import org.terasology.scenario.components.information.PlayerNameComponent;
 import org.terasology.scenario.components.information.RandomIntComponent;
 import org.terasology.scenario.components.information.TriggeringBlockComponent;
+import org.terasology.scenario.components.regions.RegionNameComponent;
 import org.terasology.scenario.internal.events.evaluationEvents.EvaluateDisplayEvent;
 import org.terasology.world.block.BlockManager;
 
@@ -131,5 +133,15 @@ public class EvaluationDisplaySystem extends BaseComponentSystem {
         String player = evalPlayer.getResult();
 
         event.setResult("Name of " + player);
+    }
+
+    @ReceiveEvent //RegionName
+    public void OnEvaluateRegionEvent(EvaluateDisplayEvent event, EntityRef entity, ConstRegionComponent comp) {
+        if (comp.regionEntity != null) {
+            event.setResult(comp.regionEntity.getComponent(RegionNameComponent.class).regionName);
+        }
+        else {
+            event.setResult("No region selected");
+        }
     }
 }

--- a/src/main/java/org/terasology/scenario/internal/systems/ComponentEvaluation/EvaluationSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/ComponentEvaluation/EvaluationSystem.java
@@ -27,6 +27,7 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.logic.inventory.InventoryComponent;
+import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.scenario.components.actions.ArgumentContainerComponent;
 import org.terasology.scenario.components.conditionals.BlockConditionalComponent;
@@ -160,7 +161,8 @@ public class EvaluationSystem extends BaseComponentSystem {
 
         //TODO: Replaced once evaluation of player is done
         TriggeringEntityComponent temp = event.getPassedEntity().getComponent(TriggeringEntityComponent.class);
-        DisplayNameComponent name = temp.entity.getComponent(DisplayNameComponent.class);
+        EntityRef clientInfo = temp.entity.getOwner().getComponent(ClientComponent.class).clientInfo;
+        DisplayNameComponent name = clientInfo.getComponent(DisplayNameComponent.class);
 
         event.setResult(name.name);
     }
@@ -185,23 +187,6 @@ public class EvaluationSystem extends BaseComponentSystem {
         EvaluateComparatorEvent evalCompare = new EvaluateComparatorEvent(event.getPassedEntity());
         args.get("compare").send(evalCompare);
 
-
-        switch (evalCompare.getResult()) {
-            case EQUAL_TO:
-                event.setResult(int1 == int2);
-                break;
-            case GREATER_THAN:
-                event.setResult(int1 > int2);
-                break;
-            case GREATER_THAN_EQUAL_TO:
-                event.setResult(int1 >= int2);
-                break;
-            case LESS_THAN:
-                event.setResult(int1 < int2);
-                break;
-            case LESS_THAN_EQUAL_TO:
-                event.setResult(int1 <= int2);
-                break;
-        }
+        event.setResult(evalCompare.getResult().evaluate(int1, int2));
     }
 }

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionDisplaySystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionDisplaySystem.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.systems;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityBuilder;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.Region3i;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.registry.In;
+import org.terasology.rendering.logic.RegionOutlineComponent;
+import org.terasology.rendering.nui.Color;
+import org.terasology.scenario.components.VisibilityComponent;
+import org.terasology.scenario.components.regions.RegionColorComponent;
+import org.terasology.scenario.components.regions.RegionLocationComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class RegionDisplaySystem extends BaseComponentSystem {
+    @In
+    private EntityManager entityManager;
+
+    @In
+    private LocalPlayer localPlayer;
+
+    private List<EntityRef> regionOutlineEntities = new ArrayList<>();
+
+    private Logger logger = LoggerFactory.getLogger(RegionDisplaySystem.class);
+
+    @ReceiveEvent
+    public void onChangedVisiblityComponent(OnChangedComponent event, EntityRef entity, VisibilityComponent component) {
+        if (entity.getOwner().equals(localPlayer.getCharacterEntity())) { //Only want to watch hub tool visiblity of local player
+            updateOutlineEntities(component);
+        }
+    }
+
+    private void updateOutlineEntities(VisibilityComponent component) {
+        List<helper> regions = getRegionsToDraw(component);
+        destroyOutlineEntities();
+
+        regionOutlineEntities.clear();
+        for (helper h : regions) {
+            EntityBuilder entityBuilder = entityManager.newBuilder();
+            entityBuilder.setPersistent(false);
+            RegionOutlineComponent regionOutlineComponent = new RegionOutlineComponent();
+            regionOutlineComponent.corner1 = new Vector3i(h.region.min());
+            regionOutlineComponent.corner2 = new Vector3i(h.region.max());
+            regionOutlineComponent.color = h.color;
+            entityBuilder.addComponent(regionOutlineComponent);
+            regionOutlineEntities.add(entityBuilder.build());
+        }
+    }
+
+    private void destroyOutlineEntities() {
+        for(EntityRef e : regionOutlineEntities) {
+            if (e.exists()) {
+                e.destroy();
+            }
+        }
+    }
+
+
+    //Not sure if terasology already has some way of doing a set/tuple for a list
+    private class helper {
+        public Region3i region;
+        public Color color;
+    }
+
+    private List<helper> getRegionsToDraw(VisibilityComponent component) {
+        List<helper> returnList = new ArrayList<>();
+        for (EntityRef e : component.visibleList) {
+            helper tempHelper = new helper();
+            tempHelper.region = e.getComponent(RegionLocationComponent.class).region;
+            tempHelper.color = e.getComponent(RegionColorComponent.class).color;
+            returnList.add(tempHelper);
+        }
+
+        return returnList;
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionSystem.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.systems;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.assets.management.AssetManager;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabManager;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.characters.events.AttackEvent;
+import org.terasology.logic.chat.ChatMessageEvent;
+import org.terasology.logic.common.DisplayNameComponent;
+import org.terasology.math.Region3i;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.network.ClientComponent;
+import org.terasology.network.ColorComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.FontColor;
+import org.terasology.rendering.nui.Color;
+import org.terasology.scenario.components.ScenarioComponent;
+import org.terasology.scenario.components.regions.RegionBeingCreatedComponent;
+import org.terasology.scenario.components.regions.RegionLocationComponent;
+import org.terasology.scenario.internal.events.RegionTreeFullAddEvent;
+
+import java.util.Iterator;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class RegionSystem extends BaseComponentSystem {
+    @In
+    private EntityManager entityManager;
+
+    @In
+    private PrefabManager prefabManager;
+
+    @In
+    private AssetManager assetManager;
+
+    private Logger logger = LoggerFactory.getLogger(RegionSystem.class);
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_CRITICAL)
+    public void onAttackEntity(AttackEvent event, EntityRef targetEntity, org.terasology.world.block.BlockComponent blockComponent) {
+        Iterator<EntityRef> entities = entityManager.getEntitiesWith(RegionBeingCreatedComponent.class).iterator();
+        if (entities.hasNext()) {
+            if (event.getDirectCause().getParentPrefab() != null && event.getDirectCause().getParentPrefab().equals(assetManager.getAsset("scenario:hubtool", Prefab.class).get())) {
+                EntityRef editedRegion = entities.next(); //SHOULD only have one region that can be edited for now, will have to change this in future with multiplayer
+                RegionBeingCreatedComponent create = editedRegion.getComponent(RegionBeingCreatedComponent.class);
+                Vector3i pos = blockComponent.getPosition();
+                if (create.firstHit == null) {
+                    create.firstHit = pos;
+
+                    DisplayNameComponent name = new DisplayNameComponent();
+                    name.name = "Scenario System";
+                    ColorComponent color = new ColorComponent();
+                    color.color = Color.RED;
+                    EntityRef ent = entityManager.create(name, color);
+
+                    EntityRef clientInfo = event.getInstigator().getOwner().getComponent(ClientComponent.class).clientInfo;
+                    String displayName = FontColor.getColored(clientInfo.getComponent(DisplayNameComponent.class).name, clientInfo.getComponent(ColorComponent.class).color);
+
+                    for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
+                        client.send(new ChatMessageEvent("Region start registered by " + displayName, ent));
+                    }
+
+                    ent.destroy();
+
+                    event.consume();
+                }
+                else {
+                    if (!pos.equals(create.firstHit)) {
+                        RegionLocationComponent loc = editedRegion.getComponent(RegionLocationComponent.class);
+                        loc.region = Region3i.createBounded(pos, create.firstHit);
+                        editedRegion.saveComponent(loc);
+                        editedRegion.removeComponent(RegionBeingCreatedComponent.class);
+                        if (entityManager.getEntitiesWith(ScenarioComponent.class).iterator().hasNext()) {
+                            EntityRef scenario = entityManager.getEntitiesWith(ScenarioComponent.class).iterator().next();
+                            if (scenario == null) {
+                                return;
+                            }
+                            scenario.send(new RegionTreeFullAddEvent(editedRegion, event.getInstigator()));
+                        }
+                        event.consume();
+                    }
+                }
+
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
@@ -76,11 +76,20 @@ public class RegionTreeSystem extends BaseComponentSystem {
     public void onRegionTreeDeleteEvent(RegionTreeDeleteEvent event, EntityRef entity, ScenarioComponent component) {
         component.regionEntities.remove(event.getDeleteEntity());
         entity.saveComponent(component);
+
+
+        for (EntityRef e : entityManager.getEntitiesWith(VisibilityComponent.class)) {
+            e.getComponent(VisibilityComponent.class).visibleList.remove(event.getDeleteEntity());
+            e.saveComponent(e.getComponent(VisibilityComponent.class));
+        }
+
         event.getDeleteEntity().destroy();
 
         if (event.getHubScreen() != null) {
             event.getHubScreen().updateRegionTree(entity);
         }
+
+
     }
 
     @ReceiveEvent

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.systems;
+
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.chat.ChatMessageEvent;
+import org.terasology.logic.common.DisplayNameComponent;
+import org.terasology.network.ClientComponent;
+import org.terasology.network.ColorComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.FontColor;
+import org.terasology.rendering.nui.Color;
+import org.terasology.scenario.components.ScenarioComponent;
+import org.terasology.scenario.components.regions.RegionBeingCreatedComponent;
+import org.terasology.scenario.components.regions.RegionColorComponent;
+import org.terasology.scenario.components.regions.RegionLocationComponent;
+import org.terasology.scenario.components.regions.RegionNameComponent;
+import org.terasology.scenario.internal.events.RegionRecolorEvent;
+import org.terasology.scenario.internal.events.RegionRenameEvent;
+import org.terasology.scenario.internal.events.RegionTreeAddEvent;
+import org.terasology.scenario.internal.events.RegionTreeDeleteEvent;
+import org.terasology.scenario.internal.events.RegionTreeFullAddEvent;
+import org.terasology.scenario.internal.events.RegionTreeMoveEntityEvent;
+
+import java.util.List;
+
+/**
+ * The system that handles all of the events for the entity version of the region tree structure.
+ */
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class RegionTreeSystem extends BaseComponentSystem {
+    @In
+    private EntityManager entityManager;
+
+    @ReceiveEvent
+    public void onRegionTreeAddEvent(RegionTreeAddEvent event, EntityRef entity, ScenarioComponent component) {
+        RegionColorComponent colorComponent = new RegionColorComponent();
+        RegionLocationComponent locationComponent = new RegionLocationComponent();
+        RegionNameComponent nameComponent = new RegionNameComponent();
+        RegionBeingCreatedComponent editComponent = new RegionBeingCreatedComponent();
+
+        //Will need to be fixed once creating multiple regions is allowed, should only delete regions
+        //currently being created by the person wanting to create a new one
+        for (EntityRef e : entityManager.getEntitiesWith(RegionBeingCreatedComponent.class)) {
+            e.destroy();
+        }
+
+
+        entityManager.create(colorComponent, locationComponent, nameComponent, editComponent);
+
+        if (event.getHubScreen() != null) {
+            event.getHubScreen().getManager().closeScreen(event.getHubScreen());
+        }
+    }
+
+    @ReceiveEvent
+    public void onRegionTreeDeleteEvent(RegionTreeDeleteEvent event, EntityRef entity, ScenarioComponent component) {
+        component.regionEntities.remove(event.getDeleteEntity());
+        entity.saveComponent(component);
+        event.getDeleteEntity().destroy();
+
+        if (event.getHubScreen() != null) {
+            event.getHubScreen().updateRegionTree(entity);
+        }
+    }
+
+    @ReceiveEvent
+    public void onRegionTreeMoveEntityEvent(RegionTreeMoveEntityEvent event, EntityRef entity, ScenarioComponent component) {
+        List<EntityRef> list = component.regionEntities;
+
+        int startIndex = list.indexOf(event.getMoveEntity());
+        int endIndex = event.getIndex();
+        if (startIndex < endIndex) {
+            list.add(endIndex, list.get(startIndex));
+            list.remove(startIndex);
+        }
+        else {
+            list.add(endIndex, list.get(startIndex));
+            list.remove(startIndex + 1);
+        }
+
+        entity.saveComponent(component);
+
+        if (event.getHubScreen() != null) {
+            event.getHubScreen().updateRegionTree(entity);
+        }
+    }
+
+    @ReceiveEvent
+    public void onRegionTreeFullAddEvent(RegionTreeFullAddEvent event, EntityRef entity, ScenarioComponent component) {
+        component.regionEntities.add(event.getAddEntity());
+        entity.saveComponent(component);
+
+        DisplayNameComponent name = new DisplayNameComponent();
+        name.name = "Scenario System";
+        ColorComponent color = new ColorComponent();
+        color.color = Color.RED;
+        EntityRef ent = entityManager.create(name, color);
+
+        EntityRef clientInfo = event.getAdder().getOwner().getComponent(ClientComponent.class).clientInfo;
+        String displayName = FontColor.getColored(clientInfo.getComponent(DisplayNameComponent.class).name, clientInfo.getComponent(ColorComponent.class).color);
+
+        for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
+            client.send(new ChatMessageEvent("Region created by " + displayName, ent));
+        }
+
+        ent.destroy();
+    }
+
+    @ReceiveEvent
+    public void onRegionRenameEvent(RegionRenameEvent event, EntityRef entity, ScenarioComponent component) {
+        event.getRegionEntity().getComponent(RegionNameComponent.class).regionName = event.getNewName();
+        event.getRegionEntity().saveComponent(event.getRegionEntity().getComponent(RegionNameComponent.class));
+
+        entity.saveComponent(component);
+        if (event.getHubScreen() != null) {
+            event.getHubScreen().updateRegionTree(entity);
+        }
+    }
+
+    @ReceiveEvent
+    public void onRegionRecolorEvent(RegionRecolorEvent event, EntityRef entity, ScenarioComponent component) {
+        event.getRegionEntity().getComponent(RegionColorComponent.class).color = event.getNewColor();
+        event.getRegionEntity().saveComponent(event.getRegionEntity().getComponent(RegionColorComponent.class));
+
+        entity.saveComponent(component);
+        if (event.getHubScreen() != null) {
+            event.getHubScreen().updateRegionTree(entity);
+        }
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
@@ -29,6 +29,7 @@ import org.terasology.registry.In;
 import org.terasology.rendering.FontColor;
 import org.terasology.rendering.nui.Color;
 import org.terasology.scenario.components.ScenarioComponent;
+import org.terasology.scenario.components.VisibilityComponent;
 import org.terasology.scenario.components.regions.RegionBeingCreatedComponent;
 import org.terasology.scenario.components.regions.RegionColorComponent;
 import org.terasology.scenario.components.regions.RegionLocationComponent;
@@ -120,6 +121,12 @@ public class RegionTreeSystem extends BaseComponentSystem {
 
         for (EntityRef client : entityManager.getEntitiesWith(ClientComponent.class)) {
             client.send(new ChatMessageEvent("Region created by " + displayName, ent));
+        }
+
+        entity.saveComponent(component);
+        for (EntityRef e : entityManager.getEntitiesWith(VisibilityComponent.class)) {
+            e.getComponent(VisibilityComponent.class).visibleList.add(event.getAddEntity());
+            e.saveComponent(e.getComponent(VisibilityComponent.class));
         }
 
         ent.destroy();

--- a/src/main/java/org/terasology/scenario/internal/ui/EditLogicScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/EditLogicScreen.java
@@ -42,6 +42,7 @@ import org.terasology.scenario.components.actions.ArgumentContainerComponent;
 import org.terasology.scenario.components.conditionals.ConditionalComponent;
 import org.terasology.scenario.components.events.EventComponent;
 import org.terasology.scenario.internal.events.ReplaceEntityEvent;
+import org.terasology.scenario.internal.ui.LogicTree.LogicTreeValue;
 import org.terasology.scenario.internal.utilities.ArgumentParser;
 
 import java.util.ArrayList;

--- a/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
@@ -23,6 +23,9 @@ import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.characters.CharacterMovementComponent;
+import org.terasology.logic.characters.CharacterTeleportEvent;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureUtil;
@@ -37,11 +40,13 @@ import org.terasology.rendering.nui.widgets.UISlider;
 import org.terasology.rendering.nui.widgets.UIText;
 import org.terasology.scenario.components.VisibilityComponent;
 import org.terasology.scenario.components.regions.RegionColorComponent;
+import org.terasology.scenario.components.regions.RegionLocationComponent;
 import org.terasology.scenario.components.regions.RegionNameComponent;
 import org.terasology.scenario.internal.events.RegionRecolorEvent;
 import org.terasology.scenario.internal.events.RegionRenameEvent;
 import org.terasology.scenario.internal.utilities.CieCamColorsScenario;
 import org.terasology.utilities.Assets;
+import org.terasology.world.WorldProvider;
 
 import java.math.RoundingMode;
 import java.util.List;
@@ -61,6 +66,10 @@ public class EditRegionScreen extends CoreScreenLayer {
     private UICheckbox visiblity;
     private UISlider colorSlider;
     private UIImage colorImage;
+
+    @In
+    private LocalPlayer localPlayer;
+
 
     private final List<Color> colors = CieCamColorsScenario.L65C65;
 
@@ -83,6 +92,7 @@ public class EditRegionScreen extends CoreScreenLayer {
 
         WidgetUtil.trySubscribe(this, "okButton", this::onOkButton);
         WidgetUtil.trySubscribe(this, "cancelButton", this::onCancelButton);
+        WidgetUtil.trySubscribe(this, "teleportButton", this::onTeleportButton);
     }
 
     public void setupDisplay(EntityRef entity, HubToolScreen returnScreen) {
@@ -122,6 +132,12 @@ public class EditRegionScreen extends CoreScreenLayer {
 
     public void onCancelButton(UIWidget button) {
         getManager().popScreen();
+    }
+
+    public void onTeleportButton(UIWidget button) {
+        org.terasology.math.geom.Vector3f location = baseEntity.getComponent(RegionLocationComponent.class).region.center();
+        CharacterTeleportEvent tele = new CharacterTeleportEvent(location);
+        localPlayer.getCharacterEntity().send(tele);
     }
 
     @Override

--- a/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.ui;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.math.DoubleMath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.assets.ResourceUrn;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.texture.Texture;
+import org.terasology.rendering.assets.texture.TextureUtil;
+import org.terasology.rendering.nui.Color;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.UIWidget;
+import org.terasology.rendering.nui.WidgetUtil;
+import org.terasology.rendering.nui.databinding.DefaultBinding;
+import org.terasology.rendering.nui.widgets.UICheckbox;
+import org.terasology.rendering.nui.widgets.UIImage;
+import org.terasology.rendering.nui.widgets.UISlider;
+import org.terasology.rendering.nui.widgets.UIText;
+import org.terasology.scenario.components.VisibilityComponent;
+import org.terasology.scenario.components.regions.RegionColorComponent;
+import org.terasology.scenario.components.regions.RegionNameComponent;
+import org.terasology.scenario.internal.events.RegionRecolorEvent;
+import org.terasology.scenario.internal.events.RegionRenameEvent;
+import org.terasology.scenario.internal.utilities.CieCamColorsScenario;
+import org.terasology.utilities.Assets;
+
+import java.math.RoundingMode;
+import java.util.List;
+
+public class EditRegionScreen extends CoreScreenLayer {
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("scenario:editRegionScreen!instance");
+
+    private static final Logger logger = LoggerFactory.getLogger(EditRegionScreen.class);
+
+    @In
+    EntityManager entityManager;
+
+    private HubToolScreen returnScreen;
+    private EntityRef baseEntity;
+
+    private UIText nameEntry;
+    private UICheckbox visiblity;
+    private UISlider colorSlider;
+    private UIImage colorImage;
+
+    private final List<Color> colors = CieCamColorsScenario.L65C65;
+
+    @Override
+    public void initialise() {
+        nameEntry = find("nameEntry", UIText.class);
+        visiblity = find("visibility", UICheckbox.class);
+        colorSlider = find("colorSlider", UISlider.class);
+        colorImage = find("colorImage", UIImage.class);
+
+        colorSlider.setIncrement(0.01f);
+        Function<Object, String> constant = Functions.constant("  ");   // ensure a certain width
+        colorSlider.setLabelFunction(constant);
+
+        if (colorImage != null) {
+            ResourceUrn uri = TextureUtil.getTextureUriForColor(Color.WHITE);
+            Texture tex = Assets.get(uri, Texture.class).get();
+            colorImage.setImage(tex);
+        }
+
+        WidgetUtil.trySubscribe(this, "okButton", this::onOkButton);
+        WidgetUtil.trySubscribe(this, "cancelButton", this::onCancelButton);
+    }
+
+    public void setupDisplay(EntityRef entity, HubToolScreen returnScreen) {
+        this.baseEntity = entity;
+        this.returnScreen = returnScreen;
+
+        nameEntry.setText(entity.getComponent(RegionNameComponent.class).regionName);
+        visiblity.setChecked(returnScreen.getEntity().getComponent(VisibilityComponent.class).visibleList.contains(entity));
+
+        if (colorSlider != null) {
+            Color color = entity.getComponent(RegionColorComponent.class).color;
+            colorSlider.bindValue(new NotifyingBinding(findClosestIndex(color)));
+        }
+
+        updateImage();
+    }
+
+    public void onOkButton(UIWidget button) {
+        if (!nameEntry.getText().equals(baseEntity.getComponent(RegionNameComponent.class).regionName)) {
+            returnScreen.getScenarioEntity().send(new RegionRenameEvent(baseEntity, nameEntry.getText(), returnScreen));
+        }
+        if (!colorImage.getTint().equals(baseEntity.getComponent(RegionColorComponent.class).color)) {
+            returnScreen.getScenarioEntity().send(new RegionRecolorEvent(baseEntity, colorImage.getTint(), returnScreen));
+        }
+        if (visiblity.isChecked()) {
+            VisibilityComponent vis = returnScreen.getEntity().getComponent(VisibilityComponent.class);
+            vis.visibleList.add(baseEntity);
+            returnScreen.getEntity().saveComponent(vis);
+        }
+        else {
+            VisibilityComponent vis = returnScreen.getEntity().getComponent(VisibilityComponent.class);
+            vis.visibleList.remove(baseEntity);
+            returnScreen.getEntity().saveComponent(vis);
+        }
+        getManager().popScreen();
+    }
+
+    public void onCancelButton(UIWidget button) {
+        getManager().popScreen();
+    }
+
+    @Override
+    public boolean isLowerLayerVisible() {
+        return false;
+    }
+
+    /**
+     * Calls update() in parent class when the slider value changes
+     */
+    private final class NotifyingBinding extends DefaultBinding<Float> {
+
+        private NotifyingBinding(Float value) {
+            super(value);
+        }
+
+        @Override
+        public void set(Float v) {
+            super.set(v);
+
+            updateImage();
+        }
+    }
+
+    private float findClosestIndex(Color color) {
+        int best = 0;
+        float minDist = Float.MAX_VALUE;
+        for (int i = 0; i < colors.size(); i++) {
+            Color other = colors.get(i);
+            float dr = other.rf() - color.rf();
+            float dg = other.gf() - color.gf();
+            float db = other.bf() - color.bf();
+
+            // there are certainly smarter ways to measure color distance,
+            // but Euclidean distance is good enough for the purpose
+            float dist = dr * dr + dg * dg + db * db;
+            if (dist < minDist) {
+                minDist = dist;
+                best = i;
+            }
+        }
+
+        float max = colors.size() - 1;
+        return best / max;
+    }
+
+    private void updateImage() {
+        Color color = getColor();
+        if (colorImage != null) {
+            colorImage.setTint(color);
+        }
+    }
+
+    private Color getColor() {
+        if (colorSlider != null) {
+            float index = colorSlider.getValue();
+            return findClosestColor(index);
+        }
+        else {
+            return baseEntity.getComponent(RegionColorComponent.class).color;
+        }
+    }
+
+    private Color findClosestColor(float findex) {
+        int index = DoubleMath.roundToInt(findex * (colors.size() - 1), RoundingMode.HALF_UP);
+        Color color = colors.get(index);
+        return color;
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/ui/HubToolScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/HubToolScreen.java
@@ -584,10 +584,6 @@ public class HubToolScreen extends BaseInteractionScreen {
         returnTree.setExpanded(true);
 
         for (EntityRef e : scenario.regionEntities) {
-            if (!getInteractionTarget().getComponent(VisibilityComponent.class).visibleList.contains(e)){
-                getInteractionTarget().getComponent(VisibilityComponent.class).visibleList.add(e);
-                getInteractionTarget().saveComponent(getInteractionTarget().getComponent(VisibilityComponent.class));
-            }
             returnTree.addChild(new RegionTreeValue(e));
         }
 

--- a/src/main/java/org/terasology/scenario/internal/ui/HubToolScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/HubToolScreen.java
@@ -35,7 +35,6 @@ import org.terasology.scenario.components.TriggerActionListComponent;
 import org.terasology.scenario.components.TriggerConditionListComponent;
 import org.terasology.scenario.components.TriggerEventListComponent;
 import org.terasology.scenario.components.TriggerNameComponent;
-import org.terasology.scenario.components.VisibilityComponent;
 import org.terasology.scenario.internal.events.LogicTreeAddActionEvent;
 import org.terasology.scenario.internal.events.LogicTreeAddConditionEvent;
 import org.terasology.scenario.internal.events.LogicTreeAddEventEvent;
@@ -607,4 +606,10 @@ public class HubToolScreen extends BaseInteractionScreen {
         editRegion.setupDisplay(node.getValue().getEntity(), this);
     }
 
+    /**
+     * Function for requesting that this screen pop itself from the manager
+     */
+    public void requestPop() {
+        getManager().popScreen();
+    }
 }

--- a/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicItemRenderer.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicItemRenderer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.internal.ui;
+package org.terasology.scenario.internal.ui.LogicTree;
 
 import org.terasology.math.geom.Rect2i;
 import org.terasology.math.geom.Vector2i;
@@ -22,6 +22,7 @@ import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.Canvas;
 import org.terasology.rendering.nui.TextLineBuilder;
 import org.terasology.rendering.nui.itemRendering.AbstractItemRenderer;
+import org.terasology.scenario.internal.ui.LogicTree.LogicTreeValue;
 
 import java.util.List;
 

--- a/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTree.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTree.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.internal.ui;
+package org.terasology.scenario.internal.ui.LogicTree;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +21,7 @@ import org.terasology.rendering.nui.widgets.treeView.Tree;
 import org.terasology.scenario.components.ExpandedComponent;
 import org.terasology.scenario.components.TriggerNameComponent;
 import org.terasology.scenario.internal.events.LogicTreeMoveEntityEvent;
+import org.terasology.scenario.internal.ui.HubToolScreen;
 
 
 public class LogicTree extends Tree<LogicTreeValue> {

--- a/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTreeMenuTreeBuilder.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTreeMenuTreeBuilder.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.internal.ui;
+package org.terasology.scenario.internal.ui.LogicTree;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTreeValue.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTreeValue.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.internal.ui;
+package org.terasology.scenario.internal.ui.LogicTree;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTreeView.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/LogicTree/LogicTreeView.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.scenario.internal.ui;
+package org.terasology.scenario.internal.ui.LogicTree;
 
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.entity.EntityRef;

--- a/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionItemRenderer.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionItemRenderer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.ui.RegionTree;
+
+import org.terasology.math.geom.Rect2i;
+import org.terasology.math.geom.Vector2i;
+import org.terasology.rendering.FontColor;
+import org.terasology.rendering.assets.font.Font;
+import org.terasology.rendering.nui.Canvas;
+import org.terasology.rendering.nui.Color;
+import org.terasology.rendering.nui.TextLineBuilder;
+import org.terasology.rendering.nui.itemRendering.AbstractItemRenderer;
+import org.terasology.scenario.components.regions.RegionColorComponent;
+import org.terasology.scenario.components.regions.RegionNameComponent;
+
+import java.util.List;
+
+/**
+ * New item renderer required because it must pull all of the data from components that the normal render would not
+ * know about in order to generate the name for the region and the coloring
+ */
+public class RegionItemRenderer extends AbstractItemRenderer<RegionTreeValue> {
+    private final int marginTop;
+    private final int marginBottom;
+    private final int marginLeft;
+    private final int marginRight;
+
+    public RegionItemRenderer() {
+        this(2,2,5,5);
+    }
+
+    public RegionItemRenderer(int marginTop, int marginBottom, int marginLeft, int marginRight) {
+        this.marginTop = marginTop;
+        this.marginBottom = marginBottom;
+        this.marginLeft = marginLeft;
+        this.marginRight = marginRight;
+    }
+
+    @Override
+    public void draw(RegionTreeValue value, Canvas canvas) {
+        String text;
+
+        if (value.getEntity() == null) {
+            text = FontColor.getColored("Regions", Color.WHITE);
+        }
+        else {
+            text = FontColor.getColored(value.getEntity().getComponent(RegionNameComponent.class).regionName,
+                                        value.getEntity().getComponent(RegionColorComponent.class).color);
+        }
+
+        Rect2i textRegion = Rect2i.createFromMinAndSize(0, 0, canvas.getRegion().width(), canvas.getRegion().height());
+        canvas.drawText(text, textRegion);
+
+    }
+
+    @Override
+    public Vector2i getPreferredSize(RegionTreeValue value, Canvas canvas) {
+        Font font = canvas.getCurrentStyle().getFont();
+        String text;
+
+        if (value.getEntity() == null) {
+            text = "Regions";
+        }
+        else {
+            text = value.getEntity().getComponent(RegionNameComponent.class).regionName;
+        }
+
+        List<String> lines = TextLineBuilder.getLines(font, text, canvas.size().x);
+        return font.getSize(lines);
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionTree.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionTree.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.ui.RegionTree;
+
+import org.terasology.rendering.nui.widgets.treeView.Tree;
+import org.terasology.scenario.internal.events.RegionTreeMoveEntityEvent;
+import org.terasology.scenario.internal.ui.HubToolScreen;
+
+public class RegionTree extends Tree<RegionTreeValue> {
+    private HubToolScreen hubToolScreen;
+
+    public RegionTree(HubToolScreen hubToolScreen) {
+        this.hubToolScreen = hubToolScreen;
+    }
+
+    public RegionTree(RegionTreeValue value, HubToolScreen hubToolScreen) {
+        setValue(value);
+        this.hubToolScreen = hubToolScreen;
+    }
+
+    @Override
+    public boolean acceptsChild(Tree<RegionTreeValue> child) {
+        return (getValue().getEntity() == null && child.getValue().getEntity() != null) && super.acceptsChild(child);
+    }
+
+    @Override
+    public void addChild(RegionTreeValue childValue) {
+        addChild(new RegionTree(childValue, hubToolScreen));
+    }
+
+    @Override
+    public void addChild(int index, Tree<RegionTreeValue> child) { //Allows for re-ordering of regions to actually maintain
+        hubToolScreen.getScenarioEntity().send(new RegionTreeMoveEntityEvent(child.getValue().getEntity(), index, hubToolScreen));
+    }
+
+    @Override
+    public Tree<RegionTreeValue> copy(){
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionTreeValue.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionTreeValue.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.ui.RegionTree;
+
+import org.terasology.entitySystem.entity.EntityRef;
+
+/**
+ * Simple value for displaying regions in the hub tool. Just holds a entity that it matches with.
+ * Any edits are done on the entity side and updates aren't made with out updated an entity which would cause a rebuild
+ * of the tree anyways so no need to store temporary values within the value, searching for the components is fine.
+ */
+public class RegionTreeValue {
+    private EntityRef entity;
+
+    public RegionTreeValue(EntityRef entity) {
+        this.entity = entity;
+    }
+
+    public EntityRef getEntity() {
+        return entity;
+    }
+
+    public void setEntity(EntityRef entity) {
+        this.entity = entity;
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionTreeView.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/RegionTree/RegionTreeView.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.ui.RegionTree;
+
+import org.terasology.input.MouseInput;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.contextMenu.ContextMenuUtils;
+import org.terasology.rendering.nui.contextMenu.MenuTree;
+import org.terasology.rendering.nui.widgets.UITreeView;
+
+import java.util.function.Function;
+
+public class RegionTreeView extends UITreeView<RegionTreeValue> {
+    private Function<RegionTree, MenuTree> contextMenuTreeProducer;
+
+    public RegionTreeView() {
+        super();
+        setItemRenderer(new RegionItemRenderer());
+    }
+
+    public RegionTreeView(String id) {
+        super(id);
+        setItemRenderer(new RegionItemRenderer());
+    }
+
+    public void setContextMenuTreeProducer(Function<RegionTree, MenuTree> contextMenuTreeProducer) {
+        this.contextMenuTreeProducer = contextMenuTreeProducer;
+    }
+
+    public void setEditor(NUIManager manager) {
+        subscribeNodeClick((event, node) -> {
+            if (event.getMouseButton() == MouseInput.MOUSE_RIGHT) {
+                setSelectedIndex(getModel().indexOf(node));
+                setAlternativeWidget(null);
+
+                MenuTree menuTree = contextMenuTreeProducer.apply((RegionTree) node);
+                ContextMenuUtils.showContextMenu(manager, event.getMouse().getPosition(), menuTree);
+            }
+        });
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/utilities/ArgumentParser.java
+++ b/src/main/java/org/terasology/scenario/internal/utilities/ArgumentParser.java
@@ -113,6 +113,9 @@ public class ArgumentParser {
             else if (type.equals("Comparator")) {
                 args.arguments.put(key, entityManager.create(assetManager.getAsset("scenario:scenarioConstantComparator", Prefab.class).get()));
             }
+            else if (type.equals("Region")) {
+                args.arguments.put(key, entityManager.create(assetManager.getAsset("scenario:scenarioConstantRegion", Prefab.class).get()));
+            }
             else {
                 //String parsed incorrectly, should throw some kind of exception probably
                 return;

--- a/src/main/java/org/terasology/scenario/internal/utilities/CieCamColorsScenario.java
+++ b/src/main/java/org/terasology/scenario/internal/utilities/CieCamColorsScenario.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.scenario.internal.utilities;
+
+import com.google.common.collect.ImmutableList;
+import org.terasology.rendering.nui.Color;
+
+
+/**
+ * Viewing conditions are modeled after sRGB's "typical" viewing environment with 200 cd/m2.
+ * Consecutive colors have a delta E distance of at least 1.
+ * Delta E distance is defined in CAM02-UCS as published in "Uniform Colour Spaces Based on
+ * CIECAM02 Colour Appearance Model" (Luo et al.)
+ */
+public final class CieCamColorsScenario {
+
+    /**
+     * Luminance (in CIE-Lch) is 65 for all color tones, Chroma is at 65.
+     * The entire hue circle is sampled (non-linearly).
+     * The color plane is transformed with some clipping (mostly blue and red) into RGB.
+     */
+    public static final ImmutableList<Color> L65C65 = ImmutableList.of(
+            new Color(0xFF77AEFF), new Color(0xFF77ABFF), new Color(0xFF77A8FF), new Color(0xFF77A5FF),
+            new Color(0xFF78A2FF), new Color(0xFF789FFF), new Color(0xFF789BFF), new Color(0xFF7898FF),
+            new Color(0xFF7895FF), new Color(0xFF7992FF), new Color(0xFF798FFF), new Color(0xFF798CFF),
+            new Color(0xFF7989FF), new Color(0xFF7A86FF), new Color(0xFF7A82FF), new Color(0xFF7B7FFF),
+            new Color(0xFF7B7CFF), new Color(0xFF7B79FF), new Color(0xFF7C76FF), new Color(0xFF7D73FF),
+            new Color(0xFF7D6FFF), new Color(0xFF7E6CFF), new Color(0xFF7E69FF), new Color(0xFF7F66FF),
+            new Color(0xFF8062FF), new Color(0xFF815FFF), new Color(0xFF815CFF), new Color(0xFF8259FF),
+            new Color(0xFF8356FF), new Color(0xFF8453FF), new Color(0xFF8550FF), new Color(0xFF864DFF),
+            new Color(0xFF874AFF), new Color(0xFF8846FF), new Color(0xFF8943FF), new Color(0xFF8A40FF),
+            new Color(0xFF8B3DFF), new Color(0xFF8C3AFF), new Color(0xFF8D37FF), new Color(0xFF8E34FF),
+            new Color(0xFF8F31FF), new Color(0xFF902EFF), new Color(0xFF912BFF), new Color(0xFF9228FF),
+            new Color(0xFE9425FF), new Color(0xFD9522FF), new Color(0xFB961EFF), new Color(0xFA971BFF),
+            new Color(0xF89817FF), new Color(0xF79A13FF), new Color(0xF59B0FFF), new Color(0xF39C0AFF),
+            new Color(0xF29D05FF), new Color(0xF09F01FF), new Color(0xEEA000FF), new Color(0xECA100FF),
+            new Color(0xEAA200FF), new Color(0xE8A300FF), new Color(0xE6A500FF), new Color(0xE4A600FF),
+            new Color(0xE2A700FF), new Color(0xE0A800FF), new Color(0xDDAA00FF), new Color(0xDBAB00FF),
+            new Color(0xD9AC00FF), new Color(0xD6AD00FF), new Color(0xD4AF00FF), new Color(0xD2B000FF),
+            new Color(0xCFB100FF), new Color(0xCCB200FF), new Color(0xCAB300FF), new Color(0xC7B500FF),
+            new Color(0xC4B600FF), new Color(0xC2B700FF), new Color(0xBFB804FF), new Color(0xBCB90AFF),
+            new Color(0xB9BA0FFF), new Color(0xB6BB13FF), new Color(0xB3BC17FF), new Color(0xB0BE1BFF),
+            new Color(0xADBF1FFF), new Color(0xA9C022FF), new Color(0xA6C125FF), new Color(0xA3C229FF),
+            new Color(0x9FC32CFF), new Color(0x9CC42FFF), new Color(0x98C532FF), new Color(0x94C535FF),
+            new Color(0x91C638FF), new Color(0x8DC73BFF), new Color(0x89C83FFF), new Color(0x85C942FF),
+            new Color(0x81CA45FF), new Color(0x7DCB48FF), new Color(0x78CB4BFF), new Color(0x74CC4EFF),
+            new Color(0x6FCD51FF), new Color(0x6BCE54FF), new Color(0x66CE57FF), new Color(0x60CF5AFF),
+            new Color(0x5BD05DFF), new Color(0x55D060FF), new Color(0x4FD163FF), new Color(0x49D266FF),
+            new Color(0x41D269FF), new Color(0x39D36CFF), new Color(0x30D36FFF), new Color(0x25D472FF),
+            new Color(0x15D475FF), new Color(0x00D578FF), new Color(0x00D57BFF), new Color(0x00D57EFF),
+            new Color(0x00D681FF), new Color(0x00D684FF), new Color(0x00D787FF), new Color(0x00D78AFF),
+            new Color(0x00D78DFF), new Color(0x00D790FF), new Color(0x00D893FF), new Color(0x00D896FF),
+            new Color(0x00D899FF), new Color(0x00D89CFF), new Color(0x00D89FFF), new Color(0x00D8A2FF),
+            new Color(0x00D8A5FF), new Color(0x00D9A8FF), new Color(0x00D9ABFF), new Color(0x00D9AEFF),
+            new Color(0x00D9B1FF), new Color(0x00D8B4FF), new Color(0x00D8B7FF), new Color(0x00D8BAFF),
+            new Color(0x00D8BDFF), new Color(0x00D8C0FF), new Color(0x00D8C3FF), new Color(0x00D8C6FF),
+            new Color(0x00D7C9FF), new Color(0x00D7CBFF), new Color(0x00D7CEFF), new Color(0x00D7D1FF),
+            new Color(0x00D6D4FF), new Color(0x00D6D7FF), new Color(0x00D5DAFF), new Color(0x00D5DDFF),
+            new Color(0x00D5DFFF), new Color(0x00D4E2FF), new Color(0x00D4E5FF), new Color(0x00D3E8FF),
+            new Color(0x00D2EBFF), new Color(0x00D2EDFF), new Color(0x00D1F0FF), new Color(0x00D0F3FF),
+            new Color(0x00D0F5FF), new Color(0x00CFF8FF), new Color(0x00CEFBFF), new Color(0x00CDFDFF),
+            new Color(0x00CDFFFF), new Color(0x00CCFFFF), new Color(0x00CBFFFF), new Color(0x00CAFFFF),
+            new Color(0x00C9FFFF), new Color(0x00C8FFFF), new Color(0x00C7FFFF), new Color(0x12C6FFFF),
+            new Color(0x25C5FFFF), new Color(0x32C3FFFF), new Color(0x3CC2FFFF), new Color(0x45C1FFFF),
+            new Color(0x4DC0FFFF), new Color(0x55BFFFFF), new Color(0x5BBDFFFF), new Color(0x62BCFFFF),
+            new Color(0x68BBFFFF), new Color(0x6EB9FFFF), new Color(0x73B8FFFF), new Color(0x78B6FFFF),
+            new Color(0x7DB5FFFF), new Color(0x82B4FFFF), new Color(0x87B2FFFF), new Color(0x8BB1FFFF),
+            new Color(0x90AFFFFF), new Color(0x94AEFFFF), new Color(0x98ACFFFF), new Color(0x9CABFFFF),
+            new Color(0xA0A9FFFF), new Color(0xA4A8FFFF), new Color(0xA8A6FFFF), new Color(0xACA5FFFF),
+            new Color(0xAFA4FFFF), new Color(0xB2A2FFFF), new Color(0xB6A1FFFF), new Color(0xB99FFFFF),
+            new Color(0xBC9EFFFF), new Color(0xBF9DFFFF), new Color(0xC29BFFFF), new Color(0xC59AFFFF),
+            new Color(0xC898FFFF), new Color(0xCB97FFFF), new Color(0xCD96FFFF), new Color(0xD094FFFF),
+            new Color(0xD393FFFF), new Color(0xD592FFFF), new Color(0xD791FFFF), new Color(0xDA90FFFF),
+            new Color(0xDC8EFFFF), new Color(0xDE8DFFFF), new Color(0xE18CFFFF), new Color(0xE38BFFFF),
+            new Color(0xE58AFFFF), new Color(0xE689FFFF), new Color(0xE888FFFF), new Color(0xEA87FFFF),
+            new Color(0xEC86FFFF), new Color(0xEE85FFFF), new Color(0xF084FFFF), new Color(0xF183FFFF),
+            new Color(0xF383FFFF), new Color(0xF582FCFF), new Color(0xF681FAFF), new Color(0xF880F7FF),
+            new Color(0xF980F5FF), new Color(0xFA7FF2FF), new Color(0xFC7EEFFF), new Color(0xFD7EEDFF),
+            new Color(0xFE7DEAFF), new Color(0xFF7DE7FF), new Color(0xFF7CE4FF), new Color(0xFF7BE1FF),
+            new Color(0xFF7BDEFF), new Color(0xFF7BDBFF), new Color(0xFF7AD8FF), new Color(0xFF7AD5FF),
+            new Color(0xFF79D2FF), new Color(0xFF79CFFF), new Color(0xFF79CCFF), new Color(0xFF78C9FF),
+            new Color(0xFF78C6FF), new Color(0xFF78C2FF), new Color(0xFF78BFFF), new Color(0xFF78BCFF),
+            new Color(0xFF78B9FF), new Color(0xFF77B5FF));
+
+
+    private CieCamColorsScenario() {
+        // no instances
+    }
+}


### PR DESCRIPTION
Implemented basic region addition and editing.

Region tab added to hubtool, right click to "add a region" this closes hubtool and will monitor the next 2 left-clicks using the hubtool. It will ignore any clicks made with other tools and not cause problems, will notify on first left click and second left click(must be a different location than the first, might remove this in case we want 1x1 regions, which might actually be useful). If you try to create a new region during the process of creating one it will get rid of the one you were in the process of creating. During creating a region should not conflict with anything else, you can edit logic, edit the world, etc just as you would normally.

Open hubtool again after creation to see the new region, regions can be edited to change the visibility, color, and name. Visibility is client side, name and color are based on the entityTree built for regions.

The colors are pulled from the engine code, but were not able to be used by the module due to permissions(probably an API issue again), but I did not believe that a color immutable built into the engine would really be used by modules anyways so it is more just a recreation of the same thing because I did not think the time to create my own color selection would be a good use of time currently.

Updates from last feedbacks:
Comparator converted fully into the enum built into the component
New methods for repeated code blocks.

Currently not too clean on code with commenting and such, wanted to get it out for flo to review when time is available.