### PR TITLE
Update visibility of regions

### DIFF
--- a/src/main/java/org/terasology/scenario/components/ScenarioRegionVisibilityComponent.java
+++ b/src/main/java/org/terasology/scenario/components/ScenarioRegionVisibilityComponent.java
@@ -25,6 +25,6 @@ import java.util.Set;
  * Component attached to a hubtool that includes a set of all of the region entities that should be visible to the
  * local player (visibility of the regions are ticked to true)
  */
-public class VisibilityComponent implements Component {
+public class ScenarioRegionVisibilityComponent implements Component {
     public Set<EntityRef> visibleList = new HashSet<>();
 }

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
@@ -29,7 +29,7 @@ import org.terasology.registry.In;
 import org.terasology.rendering.FontColor;
 import org.terasology.rendering.nui.Color;
 import org.terasology.scenario.components.ScenarioComponent;
-import org.terasology.scenario.components.VisibilityComponent;
+import org.terasology.scenario.components.ScenarioRegionVisibilityComponent;
 import org.terasology.scenario.components.regions.RegionBeingCreatedComponent;
 import org.terasology.scenario.components.regions.RegionColorComponent;
 import org.terasology.scenario.components.regions.RegionContainingEntitiesComponent;
@@ -80,9 +80,9 @@ public class RegionTreeSystem extends BaseComponentSystem {
         entity.saveComponent(component);
 
 
-        for (EntityRef e : entityManager.getEntitiesWith(VisibilityComponent.class)) {
-            e.getComponent(VisibilityComponent.class).visibleList.remove(event.getDeleteEntity());
-            e.saveComponent(e.getComponent(VisibilityComponent.class));
+        for (EntityRef e : entityManager.getEntitiesWith(ScenarioRegionVisibilityComponent.class)) {
+            e.getComponent(ScenarioRegionVisibilityComponent.class).visibleList.remove(event.getDeleteEntity());
+            e.saveComponent(e.getComponent(ScenarioRegionVisibilityComponent.class));
         }
 
         event.getDeleteEntity().destroy();
@@ -135,10 +135,10 @@ public class RegionTreeSystem extends BaseComponentSystem {
         }
 
         entity.saveComponent(component);
-        for (EntityRef e : entityManager.getEntitiesWith(VisibilityComponent.class)) {
-            e.getComponent(VisibilityComponent.class).visibleList.add(event.getAddEntity());
-            e.saveComponent(e.getComponent(VisibilityComponent.class));
-        }
+        EntityRef addingCharacter = event.getAdder().getOwner().getComponent(ClientComponent.class).character;
+
+        addingCharacter.getComponent(ScenarioRegionVisibilityComponent.class).visibleList.add(event.getAddEntity());
+        addingCharacter.saveComponent(addingCharacter.getComponent(ScenarioRegionVisibilityComponent.class));
 
         ent.destroy();
     }

--- a/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
@@ -23,9 +23,9 @@ import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.logic.characters.CharacterMovementComponent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
 import org.terasology.rendering.assets.texture.TextureUtil;
@@ -38,7 +38,7 @@ import org.terasology.rendering.nui.widgets.UICheckbox;
 import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UISlider;
 import org.terasology.rendering.nui.widgets.UIText;
-import org.terasology.scenario.components.VisibilityComponent;
+import org.terasology.scenario.components.ScenarioRegionVisibilityComponent;
 import org.terasology.scenario.components.regions.RegionColorComponent;
 import org.terasology.scenario.components.regions.RegionLocationComponent;
 import org.terasology.scenario.components.regions.RegionNameComponent;
@@ -46,7 +46,6 @@ import org.terasology.scenario.internal.events.RegionRecolorEvent;
 import org.terasology.scenario.internal.events.RegionRenameEvent;
 import org.terasology.scenario.internal.utilities.CieCamColorsScenario;
 import org.terasology.utilities.Assets;
-import org.terasology.world.WorldProvider;
 
 import java.math.RoundingMode;
 import java.util.List;
@@ -100,7 +99,7 @@ public class EditRegionScreen extends CoreScreenLayer {
         this.returnScreen = returnScreen;
 
         nameEntry.setText(entity.getComponent(RegionNameComponent.class).regionName);
-        visiblity.setChecked(returnScreen.getEntity().getComponent(VisibilityComponent.class).visibleList.contains(entity));
+        visiblity.setChecked(returnScreen.getEntity().getOwner().getComponent(ScenarioRegionVisibilityComponent.class).visibleList.contains(entity));
 
         if (colorSlider != null) {
             Color color = entity.getComponent(RegionColorComponent.class).color;
@@ -118,14 +117,14 @@ public class EditRegionScreen extends CoreScreenLayer {
             returnScreen.getScenarioEntity().send(new RegionRecolorEvent(baseEntity, colorImage.getTint(), returnScreen));
         }
         if (visiblity.isChecked()) {
-            VisibilityComponent vis = returnScreen.getEntity().getComponent(VisibilityComponent.class);
+            ScenarioRegionVisibilityComponent vis = returnScreen.getEntity().getOwner().getComponent(ScenarioRegionVisibilityComponent.class);
             vis.visibleList.add(baseEntity);
-            returnScreen.getEntity().saveComponent(vis);
+            returnScreen.getEntity().getOwner().saveComponent(vis);
         }
         else {
-            VisibilityComponent vis = returnScreen.getEntity().getComponent(VisibilityComponent.class);
+            ScenarioRegionVisibilityComponent vis = returnScreen.getEntity().getOwner().getComponent(ScenarioRegionVisibilityComponent.class);
             vis.visibleList.remove(baseEntity);
-            returnScreen.getEntity().saveComponent(vis);
+            returnScreen.getEntity().getOwner().saveComponent(vis);
         }
         getManager().popScreen();
     }


### PR DESCRIPTION
Converts visibility of regions into a component attached to the character entity. Allows for persistence across save/loads and for each individual player. Removes it from the hubtool specifically to allow 1 person to use multiple hubtools and not conflict the visibility. 
Also renames the component to prevent any future name conflicts and provides a more descriptive name.