### PR TITLE
Added Protected Regions and Resizing functionality

### DIFF
--- a/assets/ui/editRegionScreen.ui
+++ b/assets/ui/editRegionScreen.ui
@@ -77,10 +77,35 @@
             },
             {
               "type": "RowLayout",
-              "id": "colorLayout",
+              "id": "protectedLayout",
               "layoutInfo": {
                 "position-top": {
                   "widget": "visibilityLayout",
+                  "target": "BOTTOM",
+                  "offset": 5
+                },
+                "use-content-height": true
+              },
+              "contents": [
+                {
+                  "type": "engine:UILabel",
+                  "id": "protectedLabel",
+                  "layoutInfo": {},
+                  "text": "Protected"
+                },
+                {
+                  "type": "engine:UICheckbox",
+                  "id": "protected",
+                  "layoutInfo": {}
+                }
+              ]
+            },
+            {
+              "type": "RowLayout",
+              "id": "colorLayout",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "protectedLayout",
                   "target": "BOTTOM",
                   "offset": 5
                 },

--- a/assets/ui/editRegionScreen.ui
+++ b/assets/ui/editRegionScreen.ui
@@ -7,7 +7,7 @@
         "type": "engine:UIBox",
         "id": "newWidget",
         "layoutInfo": {
-          "width": 400,
+          "width": 500,
           "height": 300,
           "position-vertical-center": {},
           "position-horizontal-center": {}
@@ -52,10 +52,89 @@
             },
             {
               "type": "RowLayout",
-              "id": "visibilityLayout",
+              "id": "sizeLayout",
               "layoutInfo": {
                 "position-top": {
                   "widget": "selectionLayout",
+                  "target": "BOTTOM",
+                  "offset": 5
+                },
+                "use-content-height": true
+              },
+              "contents": [
+                {
+                  "type": "engine:UILabel",
+                  "layoutInfo": {
+                    "relativeWidth": 0.15
+                  },
+                  "text": "Min- X:"
+                },
+                {
+                  "type": "engine:UIText",
+                  "id": "minX",
+                  "layoutInfo": {}
+                },
+                {
+                  "type": "engine:UILabel",
+                  "layoutInfo": {},
+                  "text": "Y:"
+                },
+                {
+                  "type": "engine:UIText",
+                  "id": "minY",
+                  "layoutInfo": {}
+                },
+                {
+                  "type": "engine:UILabel",
+                  "layoutInfo": {},
+                  "text": "Z:"
+                },
+                {
+                  "type": "engine:UIText",
+                  "id": "minZ",
+                  "layoutInfo": {}
+                },
+                {
+                  "type": "engine:UILabel",
+                  "layoutInfo": {
+                    "relativeWidth": 0.15
+                  },
+                  "text": "Size- X:"
+                },
+                {
+                  "type": "engine:UIText",
+                  "id": "sizeX",
+                  "layoutInfo": {}
+                },
+                {
+                  "type": "engine:UILabel",
+                  "layoutInfo": {},
+                  "text": "Y:"
+                },
+                {
+                  "type": "engine:UIText",
+                  "id": "sizeY",
+                  "layoutInfo": {}
+                },
+                {
+                  "type": "engine:UILabel",
+                  "id": "selectLabel",
+                  "layoutInfo": {},
+                  "text": "Z:"
+                },
+                {
+                  "type": "engine:UIText",
+                  "id": "sizeZ",
+                  "layoutInfo": {}
+                }
+              ]
+            },
+            {
+              "type": "RowLayout",
+              "id": "visibilityLayout",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "sizeLayout",
                   "target": "BOTTOM",
                   "offset": 5
                 },
@@ -140,7 +219,7 @@
                 "position-top": {
                   "widget": "colorLayout",
                   "target": "BOTTOM",
-                  "offset": 40
+                  "offset": 5
                 },
                 "use-content-height": true
               },

--- a/module.txt
+++ b/module.txt
@@ -7,6 +7,9 @@
     "dependencies" : [{
             "id" : "Core",
             "minVersion" : "1.0.0"
+        },{
+            "id" : "StructureTemplates",
+            "minVersion" : "0.2.0"
         }],
     "serverSideOnly" : false
 }

--- a/src/main/java/org/terasology/scenario/internal/events/RegionProtectEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionProtectEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.events;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.rendering.nui.Color;
+import org.terasology.scenario.internal.ui.HubToolScreen;
+
+public class RegionProtectEvent implements Event {
+    private EntityRef entity;
+    private boolean isProtected;
+    private HubToolScreen hubToolScreen;
+
+    public RegionProtectEvent(EntityRef entity, boolean isProtected, HubToolScreen hubToolScreen) {
+        this.entity = entity;
+        this.isProtected = isProtected;
+        this.hubToolScreen = hubToolScreen;
+    }
+
+    public EntityRef getRegionEntity() {
+        return entity;
+    }
+
+    public boolean isProtected() {
+        return isProtected;
+    }
+
+    public HubToolScreen getHubScreen() {
+        return hubToolScreen;
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/events/RegionResizeEvent.java
+++ b/src/main/java/org/terasology/scenario/internal/events/RegionResizeEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.scenario.internal.events;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.Region3i;
+import org.terasology.scenario.internal.ui.HubToolScreen;
+
+public class RegionResizeEvent implements Event {
+    private EntityRef entity;
+    private Region3i region;
+    private HubToolScreen hubToolScreen;
+
+    public RegionResizeEvent(EntityRef entity, Region3i region, HubToolScreen hubToolScreen) {
+        this.entity = entity;
+        this.region = region;
+        this.hubToolScreen = hubToolScreen;
+    }
+
+    public EntityRef getRegionEntity() {
+        return entity;
+    }
+
+    public Region3i getRegion() {
+        return region;
+    }
+
+    public HubToolScreen getHubScreen() {
+        return hubToolScreen;
+    }
+}

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
@@ -185,7 +185,7 @@ public class RegionTreeSystem extends BaseComponentSystem {
     }
 
     @ReceiveEvent
-    public void onRegionProtectEvent(RegionProtectEvent event, EntityRef entity, ScenarioComponent component) {
+    public void onRegionProtectEvent(RegionProtectEvent event, EntityRef entity, ScenarioHubToolUpdateComponent component) {
         event.getRegionEntity().removeComponent(ProtectedRegionsComponent.class);
         if (event.isProtected()) {
             ProtectedRegionsComponent protectedRegionsComponent = new ProtectedRegionsComponent();
@@ -203,7 +203,7 @@ public class RegionTreeSystem extends BaseComponentSystem {
     }
 
     @ReceiveEvent
-    public void onRegionResizeEvent(RegionResizeEvent event, EntityRef entity, ScenarioComponent component) {
+    public void onRegionResizeEvent(RegionResizeEvent event, EntityRef entity, ScenarioHubToolUpdateComponent component) {
         RegionLocationComponent regionLocationComponent = event.getRegionEntity().getComponent(RegionLocationComponent.class);
         regionLocationComponent.region = event.getRegion();
         event.getRegionEntity().saveComponent(regionLocationComponent);

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.scenario.internal.systems;
 
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.management.AssetManager;
@@ -27,6 +28,7 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.chat.ChatMessageEvent;
 import org.terasology.logic.common.DisplayNameComponent;
+import org.terasology.math.Region3i;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.ColorComponent;
 import org.terasology.registry.In;
@@ -37,15 +39,17 @@ import org.terasology.scenario.components.ScenarioHubToolUpdateComponent;
 import org.terasology.scenario.components.ScenarioRegionVisibilityComponent;
 import org.terasology.scenario.components.regions.RegionBeingCreatedComponent;
 import org.terasology.scenario.components.regions.RegionColorComponent;
-import org.terasology.scenario.components.regions.RegionContainingEntitiesComponent;
 import org.terasology.scenario.components.regions.RegionLocationComponent;
 import org.terasology.scenario.components.regions.RegionNameComponent;
+import org.terasology.scenario.internal.events.RegionProtectEvent;
 import org.terasology.scenario.internal.events.RegionRecolorEvent;
 import org.terasology.scenario.internal.events.RegionRenameEvent;
+import org.terasology.scenario.internal.events.RegionResizeEvent;
 import org.terasology.scenario.internal.events.RegionTreeAddEvent;
 import org.terasology.scenario.internal.events.RegionTreeDeleteEvent;
 import org.terasology.scenario.internal.events.RegionTreeFullAddEvent;
 import org.terasology.scenario.internal.events.RegionTreeMoveEntityEvent;
+import org.terasology.structureTemplates.components.ProtectedRegionsComponent;
 
 import java.util.List;
 
@@ -70,8 +74,7 @@ public class RegionTreeSystem extends BaseComponentSystem {
 
         if (!scenario.iterator().hasNext()) { //No scenario exists yet
             scenarioEntity = entityManager.create(assetManager.getAsset("scenario:scenarioEntity", Prefab.class).get());
-        }
-        else {
+        } else {
             scenarioEntity = scenario.iterator().next();
         }
     }
@@ -118,8 +121,7 @@ public class RegionTreeSystem extends BaseComponentSystem {
         if (startIndex < endIndex) {
             list.add(endIndex, list.get(startIndex));
             list.remove(startIndex);
-        }
-        else {
+        } else {
             list.add(endIndex, list.get(startIndex));
             list.remove(startIndex + 1);
         }
@@ -179,6 +181,31 @@ public class RegionTreeSystem extends BaseComponentSystem {
         for (EntityRef e : entityManager.getEntitiesWith(ScenarioHubToolUpdateComponent.class)) {
             e.getComponent(ScenarioHubToolUpdateComponent.class).dirtyRegions = true;
             e.saveComponent(e.getComponent(ScenarioHubToolUpdateComponent.class));
+        }
+    }
+
+    @ReceiveEvent
+    public void onRegionProtectEvent(RegionProtectEvent event, EntityRef entity, ScenarioComponent component) {
+        event.getRegionEntity().removeComponent(ProtectedRegionsComponent.class);
+        if (event.isProtected()) {
+            ProtectedRegionsComponent protectedRegionsComponent = new ProtectedRegionsComponent();
+            List<Region3i> absoluteRegions = Lists.newArrayList();
+            absoluteRegions.add(event.getRegionEntity().getComponent(RegionLocationComponent.class).region);
+            protectedRegionsComponent.regions = absoluteRegions;
+            event.getRegionEntity().addComponent(protectedRegionsComponent);
+        }
+        if (event.getHubScreen() != null) {
+            event.getHubScreen().updateRegionTree(entity);
+        }
+    }
+
+    @ReceiveEvent
+    public void onRegionResizeEvent(RegionResizeEvent event, EntityRef entity, ScenarioComponent component) {
+        RegionLocationComponent regionLocationComponent = event.getRegionEntity().getComponent(RegionLocationComponent.class);
+        regionLocationComponent.region = event.getRegion();
+        event.getRegionEntity().saveComponent(regionLocationComponent);
+        if (event.getHubScreen() != null) {
+            event.getHubScreen().updateRegionTree(entity);
         }
     }
 }

--- a/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
+++ b/src/main/java/org/terasology/scenario/internal/systems/RegionTreeSystem.java
@@ -194,8 +194,11 @@ public class RegionTreeSystem extends BaseComponentSystem {
             protectedRegionsComponent.regions = absoluteRegions;
             event.getRegionEntity().addComponent(protectedRegionsComponent);
         }
-        if (event.getHubScreen() != null) {
-            event.getHubScreen().updateRegionTree(entity);
+
+        scenarioEntity.saveComponent(scenarioEntity.getComponent(ScenarioComponent.class));
+        for (EntityRef e : entityManager.getEntitiesWith(ScenarioHubToolUpdateComponent.class)) {
+            e.getComponent(ScenarioHubToolUpdateComponent.class).dirtyRegions = true;
+            e.saveComponent(e.getComponent(ScenarioHubToolUpdateComponent.class));
         }
     }
 
@@ -204,8 +207,11 @@ public class RegionTreeSystem extends BaseComponentSystem {
         RegionLocationComponent regionLocationComponent = event.getRegionEntity().getComponent(RegionLocationComponent.class);
         regionLocationComponent.region = event.getRegion();
         event.getRegionEntity().saveComponent(regionLocationComponent);
-        if (event.getHubScreen() != null) {
-            event.getHubScreen().updateRegionTree(entity);
+
+        scenarioEntity.saveComponent(scenarioEntity.getComponent(ScenarioComponent.class));
+        for (EntityRef e : entityManager.getEntitiesWith(ScenarioHubToolUpdateComponent.class)) {
+            e.getComponent(ScenarioHubToolUpdateComponent.class).dirtyRegions = true;
+            e.saveComponent(e.getComponent(ScenarioHubToolUpdateComponent.class));
         }
     }
 }

--- a/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
@@ -63,6 +63,7 @@ public class EditRegionScreen extends CoreScreenLayer {
 
     private UIText nameEntry;
     private UICheckbox visiblity;
+    private UICheckbox protectedRegion;
     private UISlider colorSlider;
     private UIImage colorImage;
 
@@ -76,6 +77,7 @@ public class EditRegionScreen extends CoreScreenLayer {
     public void initialise() {
         nameEntry = find("nameEntry", UIText.class);
         visiblity = find("visibility", UICheckbox.class);
+        protectedRegion = find("protected", UICheckbox.class);
         colorSlider = find("colorSlider", UISlider.class);
         colorImage = find("colorImage", UIImage.class);
 

--- a/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
@@ -17,6 +17,7 @@ package org.terasology.scenario.internal.ui;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
+import com.google.common.collect.Lists;
 import com.google.common.math.DoubleMath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.Region3i;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.rendering.assets.texture.Texture;
@@ -45,6 +47,7 @@ import org.terasology.scenario.components.regions.RegionNameComponent;
 import org.terasology.scenario.internal.events.RegionRecolorEvent;
 import org.terasology.scenario.internal.events.RegionRenameEvent;
 import org.terasology.scenario.internal.utilities.CieCamColorsScenario;
+import org.terasology.structureTemplates.components.ProtectedRegionsComponent;
 import org.terasology.utilities.Assets;
 
 import java.math.RoundingMode;
@@ -102,6 +105,7 @@ public class EditRegionScreen extends CoreScreenLayer {
 
         nameEntry.setText(entity.getComponent(RegionNameComponent.class).regionName);
         visiblity.setChecked(returnScreen.getEntity().getOwner().getComponent(ScenarioRegionVisibilityComponent.class).visibleList.contains(entity));
+        protectedRegion.setChecked(entity.hasComponent(ProtectedRegionsComponent.class));
 
         if (colorSlider != null) {
             Color color = entity.getComponent(RegionColorComponent.class).color;
@@ -122,11 +126,23 @@ public class EditRegionScreen extends CoreScreenLayer {
             ScenarioRegionVisibilityComponent vis = returnScreen.getEntity().getOwner().getComponent(ScenarioRegionVisibilityComponent.class);
             vis.visibleList.add(baseEntity);
             returnScreen.getEntity().getOwner().saveComponent(vis);
-        }
-        else {
+        } else {
             ScenarioRegionVisibilityComponent vis = returnScreen.getEntity().getOwner().getComponent(ScenarioRegionVisibilityComponent.class);
             vis.visibleList.remove(baseEntity);
             returnScreen.getEntity().getOwner().saveComponent(vis);
+        }
+        if (protectedRegion.isChecked()) {
+            if (!baseEntity.hasComponent(ProtectedRegionsComponent.class)) {
+                ProtectedRegionsComponent protectedRegionsComponent = new ProtectedRegionsComponent();
+                List<Region3i> absoluteRegions = Lists.newArrayList();
+                absoluteRegions.add(baseEntity.getComponent(RegionLocationComponent.class).region);
+                protectedRegionsComponent.regions = absoluteRegions;
+                baseEntity.addComponent(protectedRegionsComponent);
+            }
+        } else {
+            if (baseEntity.hasComponent(ProtectedRegionsComponent.class)) {
+                baseEntity.removeComponent(ProtectedRegionsComponent.class);
+            }
         }
         getManager().popScreen();
     }

--- a/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
+++ b/src/main/java/org/terasology/scenario/internal/ui/EditRegionScreen.java
@@ -143,7 +143,7 @@ public class EditRegionScreen extends CoreScreenLayer {
     }
 
     public void onOkButton(UIWidget button) {
-        returnScreen.getScenarioEntity().send(new RegionResizeEvent(baseEntity, getRegion(), returnScreen));
+        returnScreen.getEntity().send(new RegionResizeEvent(baseEntity, getRegion(), returnScreen));
 
         if (!nameEntry.getText().equals(baseEntity.getComponent(RegionNameComponent.class).regionName)) {
             returnScreen.getEntity().send(new RegionRenameEvent(baseEntity, nameEntry.getText()));
@@ -160,7 +160,7 @@ public class EditRegionScreen extends CoreScreenLayer {
             vis.visibleList.remove(baseEntity);
             returnScreen.getEntity().getOwner().saveComponent(vis);
         }
-        returnScreen.getScenarioEntity().send(new RegionProtectEvent(baseEntity, protectedRegion.isChecked(), returnScreen));
+        returnScreen.getEntity().send(new RegionProtectEvent(baseEntity, protectedRegion.isChecked(), returnScreen));
 
         getManager().popScreen();
     }


### PR DESCRIPTION
There is an additional checkbox added for the edit region screen- "Protected".

When ticked the region entity is added with a ProtectedRegionsComponent. When unticked, the component is removed.

There are 6 text fields added for `min` and `size` of the region (having `X`, `Y`, and `Z` each). Tweaking these values allows the player to resize the region.

![image](https://user-images.githubusercontent.com/13916513/28499010-71c26a62-6fc9-11e7-8012-37f7bbe4f2e0.png)
